### PR TITLE
grep chrom name in the first BED column only

### DIFF
--- a/sicer/src/remove_redundant_reads.py
+++ b/sicer/src/remove_redundant_reads.py
@@ -102,7 +102,7 @@ def strand_broken_remove(chrom, cutoff, file, chrom_reads):
 
 
 def match_by_chrom(file, chrom):
-    match = chrom + "[[:space:]]"
+    match = f"'^chrom\t'"
     matched_reads = subprocess.Popen(['grep', match, file], stdout=subprocess.PIPE) #Use Popen so that if no matches are found, it doesn't throw an exception
     chrom_reads = str(matched_reads.communicate()[0],'utf-8').splitlines()  # generates a list of each reads, which are represented by a string value
     file_name = os.path.basename(file)


### PR DESCRIPTION
Stricter grep so chromosome names without "chr" prefix can be used. Also a bit faster. Minimal code change. Tested

This is a stopgap solution since grepping through tens of millions rows for every chromosome can be replaced by i.e:
1. requiring that the input BAM/BED files are sorted by position
2. switching from ```grep``` to ```xsv``` 
3. indexing BED files with ```xsv```
4. retrieving the rows for a given chromosome, required columns only

Above makes sense if you want to introduce just the minimal code changes:
1. only ```xsv``` will need to be installed
2. BED file remains as the principal input